### PR TITLE
HLS update for 2021-03-22 URL changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ SERVER_PASSWORD="abc"
 ### Starting the streams
 
 You are now ready to start the streams. To do this, we use can use the `resync` script in `cron-scripts` to start all stations at once:
-`./cron-scripts/resync`
+```
+./cron-scripts/resync
+```
 You can verify that things started properly by going to the `audio` folder and seeing that a file is downloading. The download log should also be saved to the `logs` folder. The radio stream itself won't have started yet, because it is going to delay at least 3.5 hours (that is the time difference to the first time zone -- Newfoundland). For debugging purposes, you can play around with different delays in `start_radio.sh` to make the streams start earlier.
 
 Once the streams start, you can view them at http://192.168.0.1:8000, (remembering to use your own IP address) and you can listen by appending your mount point name. Examples:

--- a/README.md
+++ b/README.md
@@ -120,26 +120,16 @@ SERVER_PASSWORD="abc"
 
 ### Starting the streams
 
-You are now ready to start the streams. To do this, we use the `start_radio.sh` script.
-```
-run-scripts/start_radio.sh {stream name} {stream code} {stream genre}
-```
-Examples:
-```
-run-scripts/start_radio.sh "BBC Radio 1" radio1 "Pop"
-run-scripts/start_radio.sh "BBC Radio 2" radio2 "Adult Contemporary"
-run-scripts/start_radio.sh "BBC Radio 4" radio4fm "Talk"
-run-scripts/start_radio.sh "BBC Radio 5" radio5live "Talk"
-run-scripts/start_radio.sh "BBC Radio 6" 6music "Music"
-```
+You are now ready to start the streams. To do this, we use can use the `resync` script in `cron-scripts` to start all stations at once:
+`./cron-scripts/resync`
 You can verify that things started properly by going to the `audio` folder and seeing that a file is downloading. The download log should also be saved to the `logs` folder. The radio stream itself won't have started yet, because it is going to delay at least 3.5 hours (that is the time difference to the first time zone -- Newfoundland). For debugging purposes, you can play around with different delays in `start_radio.sh` to make the streams start earlier.
 
 Once the streams start, you can view them at http://192.168.0.1:8000, (remembering to use your own IP address) and you can listen by appending your mount point name. Examples:
 ```
-http://192.168.0.1:8000/radio1/3-5
-http://192.168.0.1:8000/radio2/4
-http://192.168.0.1:8000/radio4fm/5
-http://192.168.0.1:8000/radio5live/6
+http://192.168.0.1:8000/radio_one/3-5
+http://192.168.0.1:8000/radio_two/4
+http://192.168.0.1:8000/radio_fourfm/5
+http://192.168.0.1:8000/radio_five_live/6
 http://192.168.0.1:8000/6music/7
 ```
 

--- a/cron-scripts/resync
+++ b/cron-scripts/resync
@@ -5,8 +5,7 @@
 # streams tend to get un-synchronized over time (in my experience, about 2 minutes per week)
 # and by restarting them at least once a week we get everything back on track.
 
-# NOTE: This script might require a bit of manual editing. ie, right now it is hard-coded for
-# "radio2" and "radio4fm"
+# NOTE: To reduce disk usage and CPU use you can comment out the start_radio.sh lines for the stations you don't intend on using.
 
 # Also note, the order of the killings is important. First, we kill the downloader. The downloader
 # is responsible for restarting ffmpeg every time ffmpeg dies, so obviously we need to kill the
@@ -15,27 +14,73 @@
 BASE_FOLDER=
 
 # ============================================================
-# Restart radio2
+# Restart radio_one
 
-ps axf | grep downloader | grep radio2 | awk '{print "kill -9 " $1}' | sh
-ps axf | grep restart-service | grep radio2 | awk '{print "kill -9 " $1}' | sh
-ps axf | grep ffmpeg | grep radio2 | awk '{print "kill -9 " $1}' | sh
-ps axf | grep ices2 | grep radio2 | awk '{print "kill -9 " $1}' | sh
+ps axf | grep downloader | grep radio_one | awk '{print "kill -9 " $1}' | sh
+ps axf | grep restart-service | grep radio_one | awk '{print "kill -9 " $1}' | sh
+ps axf | grep ffmpeg | grep radio_one | awk '{print "kill -9 " $1}' | sh
+ps axf | grep ices2 | grep radio_one | awk '{print "kill -9 " $1}' | sh
 
-rm $BASE_FOLDER/audio/*radio2*
+rm $BASE_FOLDER/audio/*radio_one*
 
-$BASE_FOLDER/run-scripts/start_radio.sh "BBC Radio 2" radio2 "Adult Contemporary"
+$BASE_FOLDER/run-scripts/start_radio.sh "BBC Radio 1" radio_one "Pop, Dance, R&B, Rock"
 
 # ============================================================
-# Restart radio4fm
+# Restart radio_two
 
-# restart radio4fm
+ps axf | grep downloader | grep radio_two | awk '{print "kill -9 " $1}' | sh
+ps axf | grep restart-service | grep radio_two | awk '{print "kill -9 " $1}' | sh
+ps axf | grep ffmpeg | grep radio_two | awk '{print "kill -9 " $1}' | sh
+ps axf | grep ices2 | grep radio_two | awk '{print "kill -9 " $1}' | sh
 
-ps axf | grep downloader | grep radio4fm | awk '{print "kill -9 " $1}' | sh
-ps axf | grep restart-service | grep radio4fm | awk '{print "kill -9 " $1}' | sh
-ps axf | grep ffmpeg | grep radio4fm | awk '{print "kill -9 " $1}' | sh
-ps axf | grep ices2 | grep radio4fm | awk '{print "kill -9 " $1}' | sh
+rm $BASE_FOLDER/audio/*radio_two*
 
-rm $BASE_FOLDER/audio/*radio4fm*
+$BASE_FOLDER/run-scripts/start_radio.sh "BBC Radio 2" radio_two "Easy Listening, Varied Output"
 
-$BASE_FOLDER/run-scripts/start_radio.sh "BBC Radio 4" radio4fm Talk
+# ============================================================
+# Restart radio_three
+
+ps axf | grep downloader | grep radio_three | awk '{print "kill -9 " $1}' | sh
+ps axf | grep restart-service | grep radio_three | awk '{print "kill -9 " $1}' | sh
+ps axf | grep ffmpeg | grep radio_three | awk '{print "kill -9 " $1}' | sh
+ps axf | grep ices2 | grep radio_three | awk '{print "kill -9 " $1}' | sh
+
+rm $BASE_FOLDER/audio/*radio_three*
+
+$BASE_FOLDER/run-scripts/start_radio.sh "BBC Radio 3" radio_three "Classical, Opera, Arts"
+
+# ============================================================
+# Restart radio_fourfm
+
+ps axf | grep downloader | grep radio_fourfm | awk '{print "kill -9 " $1}' | sh
+ps axf | grep restart-service | grep radio_fourfm | awk '{print "kill -9 " $1}' | sh
+ps axf | grep ffmpeg | grep radio_fourfm | awk '{print "kill -9 " $1}' | sh
+ps axf | grep ices2 | grep radio_fourfm | awk '{print "kill -9 " $1}' | sh
+
+rm $BASE_FOLDER/audio/*radio_fourfm*
+
+$BASE_FOLDER/run-scripts/start_radio.sh "BBC Radio 4" radio_fourfm "Speech, Plays, Varied Output"
+
+# ============================================================
+# Restart radio_five_live
+
+ps axf | grep downloader | grep radio_five_live | awk '{print "kill -9 " $1}' | sh
+ps axf | grep restart-service | grep radio_five_live | awk '{print "kill -9 " $1}' | sh
+ps axf | grep ffmpeg | grep radio_five_live | awk '{print "kill -9 " $1}' | sh
+ps axf | grep ices2 | grep radio_five_live | awk '{print "kill -9 " $1}' | sh
+
+rm $BASE_FOLDER/audio/*radio_five_live*
+
+$BASE_FOLDER/run-scripts/start_radio.sh "BBC Radio 5" radio_five_live "News, Sport"
+
+# ============================================================
+# Restart 6music
+
+ps axf | grep downloader | grep 6music | awk '{print "kill -9 " $1}' | sh
+ps axf | grep restart-service | grep 6music | awk '{print "kill -9 " $1}' | sh
+ps axf | grep ffmpeg | grep 6music | awk '{print "kill -9 " $1}' | sh
+ps axf | grep ices2 | grep 6music | awk '{print "kill -9 " $1}' | sh
+
+rm $BASE_FOLDER/audio/*6music*
+
+$BASE_FOLDER/run-scripts/start_radio.sh "BBC Radio 6" 6music "Alternative"

--- a/run-scripts/downloader.sh
+++ b/run-scripts/downloader.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Example usage: "./downloader.sh radio2 &"
+# Example usage: "./downloader.sh radio_two &"
 
 # This script initiates initiates the download of the audio stream from the BBC servers.
 # It does basic error handling, if the stream returns a 404 error or ffmpeg fails,
@@ -10,12 +10,12 @@ BASE_FOLDER=
 
 if [ "$#" -ne 1 ]; then
     echo "Illegal number of parameters"
-    echo "Example usage: ./downloader.sh radio2"
+    echo "Example usage: ./downloader.sh radio_two"
     exit
 fi
 
-BBC_STREAM=http://bbcmedia.ic.llnwd.net/stream/bbcmedia_$1_mf_p
-
+BBC_STREAM=http://a.files.bbci.co.uk/media/live/manifesto/audio/simulcast/hls/nonuk/sbr_low/llnw/bbc_$1.m3u8 # Limelight Networks CDN
+#BBC_STREAM=http://a.files.bbci.co.uk/media/live/manifesto/audio/simulcast/hls/nonuk/sbr_low/ak/bbc_$1.m3u8 # Akamai CDN
 log="$BASE_FOLDER/logs/$1-downloader-log.txt"
 playlist="$BASE_FOLDER/logs/$1-autogen-playlist.txt"
 

--- a/run-scripts/start_radio.sh
+++ b/run-scripts/start_radio.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # usage: ./start_radio.sh {stream name} {variable stream name} {genre}
-# Example usage: ./start_radio.sh "BBC Radio 1" "radio1" "Pop"
+# Example usage: ./start_radio.sh "BBC Radio 1" radio_one "Pop"
 
 BASE_FOLDER=
 
@@ -126,7 +126,7 @@ generate_xml () {
 # Calling this will make ices2 initiate after sleeping for a specified delay. This sleeping delay is what
 # gives the impression of the time-zone delays.
 startstream () {
-    # $1: stream variable name (ie. 'radio2')
+    # $1: stream variable name (ie. 'radio_two')
     # $2: hours of delay
 
     delay=$2
@@ -138,7 +138,7 @@ startstream () {
 }
 
 startnewfiestream () {
-    #usage: $1: stream variable name (ie. 'radio2')
+    #usage: $1: stream variable name (ie. 'radio_two')
 
     # 3.5 * 60 * 60
     delay=12600
@@ -149,7 +149,7 @@ startnewfiestream () {
 
 echo "Starting $1 delayed stream" >> $logfile
 
-# Generate the xml files that will be read by ices2
+# Generate the xml files that will be read by ices2.
 generate_xml "$1" $2 "$3" "3-5" #newfoundland
 generate_xml "$1" $2 "$3" 4 #atlantic
 generate_xml "$1" $2 "$3" 5 #eastern
@@ -170,3 +170,4 @@ startstream $2 8 #pacific
 
 echo "Finished initiation of $1" >> $logfile
 
+# To save on CPU usage, you can omit specific timezones. Comment out the associated generate_xml and the startstream above.


### PR DESCRIPTION
Permanent URL changes require more than simply updating the URL. I have renamed the existing stations to match. Given that `resync` is managing the streams within a week I have changed the instructions to direct users to that file rather than messing with individual stations through `start_radio.sh`.

Associated changes with the readme.md have been made.